### PR TITLE
Register postgres with instance

### DIFF
--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -3,7 +3,7 @@
 require 'valkyrie'
 Rails.application.config.to_prepare do
   Valkyrie::MetadataAdapter.register(
-    Valkyrie::Persistence::Postgres::MetadataAdapter,
+    Valkyrie::Persistence::Postgres::MetadataAdapter.new,
     :postgres
   )
 


### PR DESCRIPTION
@awead the other adapters use an instance so it is likely to be good to use an instance for postgres too.

I asked Trey and Esme if their example on the wiki was wrong and they pointed me to registering an instance.